### PR TITLE
Add XML Sitemap

### DIFF
--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,0 +1,49 @@
+//pages/sitemap.xml.js
+const EXTERNAL_DATA_URL = "https://jsonplaceholder.typicode.com/posts";
+
+function generateSiteMap(posts) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+     <!--We manually set the two URLs we know already-->
+     <url>
+       <loc>https://jsonplaceholder.typicode.com</loc>
+     </url>
+     <url>
+       <loc>https://jsonplaceholder.typicode.com/guide</loc>
+     </url>
+     ${posts
+       .map(({ id }) => {
+         return `
+       <url>
+           <loc>${`${EXTERNAL_DATA_URL}/${id}`}</loc>
+       </url>
+     `;
+       })
+       .join("")}
+   </urlset>
+ `;
+}
+
+function SiteMap() {
+  // getServerSideProps will do the heavy lifting
+}
+
+export async function getServerSideProps({ res }) {
+  // We make an API call to gather the URLs for our site
+  const request = await fetch(EXTERNAL_DATA_URL);
+  const posts = await request.json();
+
+  // We generate the XML sitemap with the posts data
+  const sitemap = generateSiteMap(posts);
+
+  res.setHeader("Content-Type", "text/xml");
+  // we send the XML to the browser
+  res.write(sitemap);
+  res.end();
+
+  return {
+    props: {},
+  };
+}
+
+export default SiteMap;


### PR DESCRIPTION
Sitemaps are the easiest way to communicate with Google. They indicate the URLs that belong to your website and when they update so that Google can easily detect new content and crawl your website more efficiently.

Even though XML Sitemaps are the most known and used ones, they can also be created via [RSS](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap) or [Atom](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap), or even via [Text](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap) files if you prefer maximum simplicity.

A sitemap is a file where you provide information about the pages, videos, and other files on your site, and the relationships between them. Search engines like Google read this file to crawl your site.

More on sitemaps [here](https://nextjs.org/learn/seo/crawling-and-indexing/xml-sitemaps)